### PR TITLE
Device version of MP vector constructor with initialiser list.

### DIFF
--- a/packages/stokhos/test/UnitTest/Stokhos_SacadoMPVectorUnitTest_MaskTraits.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_SacadoMPVectorUnitTest_MaskTraits.cpp
@@ -568,7 +568,7 @@ TEUCHOS_UNIT_TEST( MP_Vector_MaskTraits, Mask_div)
     typedef Stokhos::StaticFixedStorage<int,double,ensemble_size,execution_space> storage_type;
     typedef Sacado::MP::Vector<storage_type> scalar;    
 
-    scalar a2 = {0.,2.};
+    scalar a2 = {0.,2.,2.,2.,2.,2.,2.,2.};
     std::cout << a2 << std::endl;
 
     scalar a = (scalar) 1.;


### PR DESCRIPTION
## Motivation

This PR:
- Adds Kokkos markup to the constructor for MP Vector taking a `std::initialiser_list`.
- Adds test.

## Related Issues

* Related to trilinos/Trilinos/pull/11311 and trilinos/Trilinos/pull/11308.
